### PR TITLE
add circuit breaker for selected tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ type Task struct {
 	//     task.rescue.io/object    1611318984211839461
 	//     task.rescue.io/worker    90dc68ba-4820-42ac-a924-2450388c15a6
 	//
+	// It is possible to define an execution limit using the circuit breaker label
+	// Cancel. A task defining a maximum execution count will be executed at most
+	// Cancel times. Once the execution limit hit the task at hand will be kept on
+	// hold until its Cycles number is reset by some external process. This allows
+	// tasks to stay on queue until a resolution for the failing root cause may be
+	// found.
+	//
+	//     task.rescue.io/cancel    5
+	//
 	Core *Core `json:"core,omitempty"`
 
 	// Cron contains optional scheduling information. A task may define to be
@@ -286,8 +295,12 @@ func (w *Worker) Filter(tas *task.Task) bool {
 
 ### Conformance Tests
 
+If you have nothing else blocking the standard redis port on your machine, then
+you can simply run the Redis docker image and execute the conformance tests
+labelled with the redis tags.
+
 ```
-docker run --rm --name redis-stack -p 6379:6379 -p 8001:8001 redis/redis-stack:latest
+docker run --rm --name redis-stack-rescue -p 6379:6379 -p 8001:8001 redis/redis-stack:latest
 ```
 
 ```
@@ -298,10 +311,14 @@ go test ./... -race -tags redis
 
 ### Redis Port
 
-```
-export REDIS_PORT=6380
-```
+If you have multiple redis instances on your machine you should use a different
+port dedicated for the Rescue conformance tests.
 
 ```
 docker run --rm --name redis-stack-rescue -p 6380:6379 -p 8002:8001 redis/redis-stack:latest
+```
+
+```
+export REDIS_PORT=6380
+go test ./... -race -tags redis
 ```

--- a/engine/create.go
+++ b/engine/create.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"strconv"
 	"time"
 
 	"github.com/xh3b4sd/rescue/task"
@@ -106,8 +107,11 @@ func (e *Engine) verCre(tas *task.Task) (*ticker.Ticker, error) {
 		if tas == nil {
 			return nil, tracer.Maskf(taskEmptyError, "Task must not be empty")
 		}
-		if tas.Core != nil {
+		if tas.Core != nil && !(tas.Core.Len() == 1 && tas.Core.Has(Can())) {
 			return nil, tracer.Maskf(taskCoreError, "Task.Core must be empty")
+		}
+		if tas.Core != nil && !(tas.Core.Has(Can()) && natNum(tas.Core.Map().Cancel())) {
+			return nil, tracer.Maskf(taskCoreError, "Task.Core does not define a positive number for %s", task.Cancel)
 		}
 		if tas.Meta == nil || tas.Meta.Emp() {
 			return nil, tracer.Maskf(taskMetaEmptyError, "Task.Meta must not be empty")
@@ -236,4 +240,9 @@ func (e *Engine) verCre(tas *task.Task) (*ticker.Ticker, error) {
 	}
 
 	return tic, nil
+}
+
+func natNum(s string) bool {
+	num, err := strconv.Atoi(s)
+	return err == nil && num > 0
 }

--- a/engine/create_test.go
+++ b/engine/create_test.go
@@ -30,6 +30,7 @@ func Test_Engine_Create_Core_Error(t *testing.T) {
 		{
 			tas: &task.Task{
 				Core: &task.Core{
+					task.Cancel: "24",
 					task.Object: "bar",
 				},
 				Meta: &task.Meta{
@@ -87,6 +88,7 @@ func Test_Engine_Create_Core_Error(t *testing.T) {
 		{
 			tas: &task.Task{
 				Core: &task.Core{
+					task.Cancel: "3",
 					task.Method: task.MthdAny,
 				},
 				Meta: &task.Meta{
@@ -100,6 +102,39 @@ func Test_Engine_Create_Core_Error(t *testing.T) {
 				Core: &task.Core{
 					task.Method: task.MthdUni,
 					task.Worker: "bar",
+				},
+				Meta: &task.Meta{
+					"foo": "bar",
+				},
+			},
+		},
+		// Case 008
+		{
+			tas: &task.Task{
+				Core: &task.Core{
+					task.Cancel: "0",
+				},
+				Meta: &task.Meta{
+					"foo": "bar",
+				},
+			},
+		},
+		// Case 009
+		{
+			tas: &task.Task{
+				Core: &task.Core{
+					task.Cancel: "-14",
+				},
+				Meta: &task.Meta{
+					"foo": "bar",
+				},
+			},
+		},
+		// Case 010
+		{
+			tas: &task.Task{
+				Core: &task.Core{
+					task.Cancel: "baz",
 				},
 				Meta: &task.Meta{
 					"foo": "bar",
@@ -121,6 +156,74 @@ func Test_Engine_Create_Core_Error(t *testing.T) {
 			err := e.Create(tc.tas)
 			if err == nil {
 				t.Fatal("expected", "error", "got", nil)
+			}
+		})
+	}
+}
+
+func Test_Engine_Create_Core_No_Error(t *testing.T) {
+	testCases := []struct {
+		tas *task.Task
+	}{
+		// Case 000
+		{
+			tas: &task.Task{
+				Core: &task.Core{
+					task.Cancel: "1",
+				},
+				Meta: &task.Meta{
+					"foo": "bar",
+				},
+			},
+		},
+		// Case 001
+		{
+			tas: &task.Task{
+				Core: &task.Core{
+					task.Cancel: "4",
+				},
+				Meta: &task.Meta{
+					"foo": "bar",
+				},
+			},
+		},
+		// Case 002
+		{
+			tas: &task.Task{
+				Core: &task.Core{
+					task.Cancel: "12",
+				},
+				Meta: &task.Meta{
+					"foo": "bar",
+				},
+			},
+		},
+		// Case 003
+		{
+			tas: &task.Task{
+				Core: &task.Core{
+					task.Cancel: "23786",
+				},
+				Meta: &task.Meta{
+					"foo": "bar",
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%03d", i), func(t *testing.T) {
+			var e *Engine
+			{
+				e = New(Config{
+					Redigo: redigo.Fake(),
+					Locker: &locker.Fake{},
+				})
+			}
+
+			err := e.Create(tc.tas)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
 			}
 		})
 	}
@@ -191,6 +294,9 @@ func Test_Engine_Create_Cron_No_Error(t *testing.T) {
 		// Case 001 ensures that @exact can be defined.
 		{
 			tas: &task.Task{
+				Core: &task.Core{
+					task.Cancel: "12",
+				},
 				Cron: &task.Cron{
 					task.Aexact: time.Now().UTC().Add(5 * time.Minute).Format(ticker.Layout),
 				},
@@ -644,6 +750,9 @@ func Test_Engine_Create_Gate_No_Error(t *testing.T) {
 		// Case 002 ensures that trigger tasks can define a multiple trigger labels.
 		{
 			tas: &task.Task{
+				Core: &task.Core{
+					task.Cancel: "10",
+				},
 				Meta: &task.Meta{
 					"foo": "bar",
 				},
@@ -835,6 +944,9 @@ func Test_Engine_Create_Sync_No_Error(t *testing.T) {
 		// Case 005
 		{
 			tas: &task.Task{
+				Core: &task.Core{
+					task.Cancel: "1",
+				},
 				Meta: &task.Meta{
 					"foo": "bar",
 				},

--- a/engine/cycles.go
+++ b/engine/cycles.go
@@ -1,0 +1,105 @@
+package engine
+
+import (
+	"fmt"
+
+	"github.com/xh3b4sd/rescue/task"
+	"github.com/xh3b4sd/tracer"
+)
+
+func (e *Engine) Cycles(tas *task.Task) error {
+	var err error
+
+	e.met.Engine.Cycles.Cal.Inc()
+
+	o := func() error {
+		err = e.cycles(tas)
+		if err != nil {
+			return tracer.Mask(err)
+		}
+
+		return nil
+	}
+
+	err = e.met.Engine.Cycles.Dur.Sin(o)
+	if err != nil {
+		e.met.Engine.Create.Err.Inc()
+		return tracer.Mask(err)
+	}
+
+	return nil
+}
+
+func (e *Engine) cycles(tas *task.Task) error {
+	var err error
+
+	{
+		if tas == nil {
+			return tracer.Maskf(taskEmptyError, "Task must not be empty")
+		}
+		if tas.Core.Emp() {
+			return tracer.Maskf(taskCoreError, "Task.Core must not be empty")
+		}
+		if !tas.Core.Has(Can()) {
+			return tracer.Maskf(taskCoreError, "Task.Core does not define %s", task.Cancel)
+		}
+	}
+
+	// Creating tasks implies certain write operations on the task queue such as
+	// adding a new task to a sorted set in redis. Due to such write operations
+	// we need to ensure that only one process at a time can write information
+	// back to the queue. Otherwise worker behaviour would be inconsistent and
+	// the integrity of the queue could not be guaranteed.
+	{
+		err := e.loc.Acquire()
+		if err != nil {
+			return tracer.Mask(err)
+		}
+
+		defer func() {
+			err := e.loc.Release()
+			if err != nil {
+				e.lerror(tracer.Mask(err))
+			}
+		}()
+	}
+
+	var jsn []string
+	{
+		k := e.Keyfmt()
+		s := float64(tas.Core.Get().Object())
+
+		jsn, err = e.red.Sorted().Search().Score(k, s, s)
+		if err != nil {
+			return tracer.Mask(err)
+		}
+	}
+
+	if len(jsn) != 1 || jsn[0] == "" {
+		return tracer.Mask(fmt.Errorf("no task found for object ID %q", tas.Core.Map().Object()))
+	}
+
+	var upd *task.Task
+	{
+		upd = task.FromString(jsn[0])
+	}
+
+	{
+		upd.Core.Prg().Expiry()
+		upd.Core.Prg().Worker()
+		upd.Core.Prg().Cycles()
+	}
+
+	{
+		k := e.Keyfmt()
+		v := task.ToString(upd)
+		s := float64(upd.Core.Get().Object())
+
+		_, err := e.red.Sorted().Update().Score(k, v, s)
+		if err != nil {
+			return tracer.Mask(err)
+		}
+	}
+
+	return nil
+}

--- a/engine/labels.go
+++ b/engine/labels.go
@@ -10,6 +10,12 @@ func All() *task.Task {
 	}
 }
 
+func Can() map[string]string {
+	return map[string]string{
+		task.Cancel: "*",
+	}
+}
+
 func Del() map[string]string {
 	return map[string]string{
 		"*": task.Deleted,

--- a/interface.go
+++ b/interface.go
@@ -12,6 +12,15 @@ type Interface interface {
 	// may be created using Task.Cron.
 	Create(tas *task.Task) error
 
+	// Cycles allows the Task.Core.Cycles label to be reset to 0, given its
+	// associated object ID. Resetting this cycles counter is only allowed for
+	// tasks that define Task.Core.Cancel as a circuit breaker in order to get
+	// halted tasks executed again.
+	//
+	//     inp[0] the object ID of the task to reset
+	//
+	Cycles(tas *task.Task) error
+
 	// Delete removes an existing task from the system. Tasks can only be deleted
 	// by the workers that own the task they have been assigned to. Task ownership
 	// cannot be cherry-picked. Deleting an expired task causes an error on the

--- a/metric/collection.go
+++ b/metric/collection.go
@@ -7,6 +7,7 @@ type Collection struct {
 
 type CollectionEngine struct {
 	Create *CollectionEngineCollector
+	Cycles *CollectionEngineCollector
 	Delete *CollectionEngineCollector
 	Exists *CollectionEngineCollector
 	Expire *CollectionEngineCollector
@@ -36,6 +37,10 @@ func (c *Collection) Reset() {
 	c.Engine.Create.Cal.Res()
 	c.Engine.Create.Dur.Res()
 	c.Engine.Create.Err.Res()
+
+	c.Engine.Cycles.Cal.Res()
+	c.Engine.Cycles.Dur.Res()
+	c.Engine.Cycles.Err.Res()
 
 	c.Engine.Delete.Cal.Res()
 	c.Engine.Delete.Dur.Res()

--- a/metric/factory.go
+++ b/metric/factory.go
@@ -10,6 +10,11 @@ func Default() *Collection {
 				Dur: &Metric{d: prometheus.NewDesc("rescue_engine_create_duration_seconds" /***/, "the number of seconds a call to Engine.Create took", nil, nil)},
 				Err: &Metric{d: prometheus.NewDesc("rescue_engine_create_error_total" /********/, "the number of errors a call to Engine.Create produced", nil, nil)},
 			},
+			Cycles: &CollectionEngineCollector{
+				Cal: &Metric{d: prometheus.NewDesc("rescue_engine_cycles_call_total" /*********/, "the number of times a call to Engine.Cycles was made", nil, nil)},
+				Dur: &Metric{d: prometheus.NewDesc("rescue_engine_cycles_duration_seconds" /***/, "the number of seconds a call to Engine.Cycles took", nil, nil)},
+				Err: &Metric{d: prometheus.NewDesc("rescue_engine_cycles_error_total" /********/, "the number of errors a call to Engine.Cycles produced", nil, nil)},
+			},
 			Delete: &CollectionEngineCollector{
 				Cal: &Metric{d: prometheus.NewDesc("rescue_engine_delete_call_total" /*********/, "the number of times a call to Engine.Delete was made", nil, nil)},
 				Dur: &Metric{d: prometheus.NewDesc("rescue_engine_delete_duration_seconds" /***/, "the number of seconds a call to Engine.Delete took", nil, nil)},

--- a/task/core_exists.go
+++ b/task/core_exists.go
@@ -14,6 +14,10 @@ func (e *exicor) Bypass() bool {
 	return e.labl[Bypass] != ""
 }
 
+func (e *exicor) Cancel() bool {
+	return e.labl[Cancel] != ""
+}
+
 func (e *exicor) Cycles() bool {
 	return e.labl[Cycles] != ""
 }

--- a/task/core_getter.go
+++ b/task/core_getter.go
@@ -30,6 +30,19 @@ func (g *getcor) Bypass() bool {
 	return byp
 }
 
+func (g *getcor) Cancel() int64 {
+	if g.labl[Cancel] == "" {
+		return 0
+	}
+
+	can, err := strconv.ParseInt(g.labl[Cancel], 10, 64)
+	if err != nil {
+		panic(err)
+	}
+
+	return can
+}
+
 func (g *getcor) Cycles() int64 {
 	if g.labl[Cycles] == "" {
 		return 0

--- a/task/core_mapper.go
+++ b/task/core_mapper.go
@@ -14,6 +14,10 @@ func (m *mapcor) Bypass() string {
 	return m.labl[Bypass]
 }
 
+func (m *mapcor) Cancel() string {
+	return m.labl[Cancel]
+}
+
 func (m *mapcor) Cycles() string {
 	return m.labl[Cycles]
 }

--- a/task/core_purger.go
+++ b/task/core_purger.go
@@ -14,6 +14,10 @@ func (p *prgcor) Bypass() {
 	delete(p.labl, Bypass)
 }
 
+func (p *prgcor) Cancel() {
+	delete(p.labl, Cancel)
+}
+
 func (p *prgcor) Cycles() {
 	delete(p.labl, Cycles)
 }

--- a/task/core_setter.go
+++ b/task/core_setter.go
@@ -21,6 +21,10 @@ func (s *setcor) Bypass(x bool) {
 	s.labl[Bypass] = strconv.FormatBool(x)
 }
 
+func (s *setcor) Cancel(x int64) {
+	s.labl[Cancel] = strconv.FormatInt(x, 10)
+}
+
 func (s *setcor) Cycles(x int64) {
 	s.labl[Cycles] = strconv.FormatInt(x, 10)
 }

--- a/task/labels.go
+++ b/task/labels.go
@@ -26,6 +26,15 @@ const (
 	// never be used, unless very good reasons demand it for special use cases.
 	Bypass = "task.rescue.io/bypass"
 
+	// Cancel is the number of maximum attempts, see task.rescue.io/cycles below.
+	// Using this circuit breaker stops executing those tasks that have hit their
+	// maximum execution limit. Tasks hitting their execution limit are not
+	// deleted, but instead are kept on queue for inspection. Resetting the cycles
+	// count of tasks that have been halted by this circuit breaker will cause
+	// those halted tasks to execute again with the goal of finally reconciling
+	// successfully.
+	Cancel = "task.rescue.io/cancel"
+
 	// Cycles is the number of attempts that workers tried to execute a given
 	// task. This number is being incremented e.g. after ownership expiration,
 	// resulting in rescheduling so that other workers can take over task

--- a/task/task.go
+++ b/task/task.go
@@ -11,6 +11,15 @@ type Task struct {
 	//     task.rescue.io/object    1611318984211839461
 	//     task.rescue.io/worker    90dc68ba-4820-42ac-a924-2450388c15a6
 	//
+	// It is possible to define an execution limit using the circuit breaker label
+	// Cancel. A task defining a maximum execution count will be executed at most
+	// Cancel times. Once the execution limit hit the task at hand will be kept on
+	// hold until its Cycles number is reset by some external process. This allows
+	// tasks to stay on queue until a resolution for the failing root cause may be
+	// found.
+	//
+	//     task.rescue.io/cancel    5
+	//
 	Core *Core `json:"core,omitempty"`
 
 	// Cron contains optional scheduling information. A task may define to be


### PR DESCRIPTION
Building out the infrastructure for the Uvio Network I ran into the problem of reconciling tasks against a blockchain. Using account abstraction and paymaster services you may run into issues that are out of your control, while you keep paying gas for reverting transactions.

So far there hasn't been a mechanism in Rescue to stop processing tasks temporarily. So far we could only keep failing or deleting tasks forever. With this change we can define an execution limit for tasks and prevent them from being executed beyond that defined limit, while keeping the task definitions on queue. We also provide a mechanism to reset the task's execution counter, in order to get them executed again, once desired.